### PR TITLE
Setup GH Actions to deploy builds to dockerhub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: '
+        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} |
+          docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        '
+      - run: docker build .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    tags:
+      - 1.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: '
+        echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} |
+          docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} --password-stdin
+        '
+      - run: echo "image_tag_latest=centrapay/aws-sam-deployer:latest" >> $GITHUB_ENV
+      - run: echo "image_tag_versioned=centrapay/aws-sam-deployer:${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - run: docker build -t "${image_tag_versioned}" .
+      - run: docker tag "${image_tag_versioned}" "${image_tag_latest}"
+      - run: docker push "${image_tag_versioned}"
+      - run: docker push "${image_tag_latest}"


### PR DESCRIPTION
This used to be done by dockerhub, but they've discontinued that free
service.

This template was coppied over from kube-deployer

Once merged, we should tag 1.1.1 and check dockerhub updates:

https://hub.docker.com/r/centrapay/aws-sam-deployer/tags